### PR TITLE
fix: pass in `maxEntries` parameter to NewsFeed

### DIFF
--- a/src/Helldivers-2-Core/Facades/V1Facade.cs
+++ b/src/Helldivers-2-Core/Facades/V1Facade.cs
@@ -76,6 +76,7 @@ public sealed class V1Facade(
     {
         var dispatches = dispatchMapper
             .MapToV1(info, translations)
+            .OrderByDescending(dispatch => dispatch.Id)
             .ToList();
 
         await dispatchStore.SetStore(dispatches);

--- a/src/Helldivers-2-Sync/Services/ArrowHeadApiService.cs
+++ b/src/Helldivers-2-Sync/Services/ArrowHeadApiService.cs
@@ -65,7 +65,7 @@ public sealed class ArrowHeadApiService(
     public async IAsyncEnumerable<NewsFeedItem> LoadFeed(string season, string language,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var request = BuildRequest($"/api/NewsFeed/{season}", language);
+        var request = BuildRequest($"/api/NewsFeed/{season}?maxEntries=1024", language);
         using var response = await http.SendAsync(request, cancellationToken);
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
 


### PR DESCRIPTION
sort dispatches when storing so newest is added first

fix #38