### PR TITLE
fix rate limits

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,6 +19,7 @@ kill_signal = 'SIGTERM'
   auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
+  max_machines_running = 1
   processes = ['app']
 
   [http_service.concurrency]
@@ -27,8 +28,8 @@ kill_signal = 'SIGTERM'
     soft_limit = 1000
 
   [[http_service.checks]]
-    grace_period = "2s"
-    interval = "120s"
+    grace_period = "10s"
+    interval = "60s"
     method = "GET"
     timeout = "10s"
     path = "/raw/api/WarSeason/current/WarID"

--- a/src/Helldivers-2-API/Program.cs
+++ b/src/Helldivers-2-API/Program.cs
@@ -7,9 +7,12 @@ using Helldivers.Models.Domain.Localization;
 using Helldivers.Sync.Configuration;
 using Helldivers.Sync.Extensions;
 using Microsoft.AspNetCore.Http.Timeouts;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Localization;
 using System.Globalization;
+using System.Net;
 using System.Text.Json.Serialization;
+using IPNetwork = Microsoft.AspNetCore.HttpOverrides.IPNetwork;
 
 #if DEBUG
 // When generating an OpenAPI document, get-document runs with the "--applicationName" flag.
@@ -66,7 +69,14 @@ builder.Services.AddCors(options =>
 });
 
 // Add and configure forwarded headers middleware
-builder.Services.Configure<ForwardedHeadersOptions>(_ => { });
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardLimit = 999;
+    options.OriginalForHeaderName = "Fly-Client-IP";
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor;
+    options.KnownNetworks.Add(new IPNetwork(IPAddress.Any, 0));
+    options.KnownNetworks.Add(new IPNetwork(IPAddress.IPv6Any, 0));
+});
 
 // This configuration is bound here so that source generators kick in.
 builder.Services.Configure<HelldiversSyncConfiguration>(builder.Configuration.GetSection("Helldivers:Synchronization"));

--- a/src/Helldivers-2-API/Program.cs
+++ b/src/Helldivers-2-API/Program.cs
@@ -154,11 +154,11 @@ app.UseRequestLocalization();
 // Ensure web applications can access the API by setting CORS headers.
 app.UseCors();
 
-// Handles rate limiting so everyone plays nice
-app.UseMiddleware<RateLimitMiddleware>();
-
 // Make sure ASP.NET Core uses the correct addresses internally rather than Fly's proxy
 app.UseForwardedHeaders();
+
+// Handles rate limiting so everyone plays nice
+app.UseMiddleware<RateLimitMiddleware>();
 
 // Add middleware to timeout requests if they take too long.
 app.UseRequestTimeouts();


### PR DESCRIPTION
currently rate limits are (once again) applied globally since the client IP address (which is used as the rate limit bucket) doesn't seem to be correctly set by the forwarded headers middleware.

tests indicate this is because it processes right to left, whereas Fly places the eventual client IP on the left.
so basically:
`<client-ip>,<proxy-1>,<proxy-2>` etc, and the app would only process `<proxy-2>` and never `<client-ip>` essentially enforcing a global rate limit per proxy region

this PR ensures that proxies are correctly processed, which in turn should fix the rate limit