### PR TITLE
fix github.io OpenAPI link

### DIFF
--- a/toc.yml
+++ b/toc.yml
@@ -1,6 +1,6 @@
 - name: Docs
   href: docs/
 - name: OpenAPI
-  href: api/docs/openapi/swagger-ui.html
+  href: docs/openapi/swagger-ui.html
 - name: API
   href: api/

--- a/toc.yml
+++ b/toc.yml
@@ -1,6 +1,6 @@
 - name: Docs
   href: docs/
 - name: OpenAPI
-  href: /docs/openapi/swagger-ui.html
+  href: api/docs/openapi/swagger-ui.html
 - name: API
   href: api/


### PR DESCRIPTION
Attempted to fix the issue with the OpenAPI link on the github.io page. Not very familiar with all the files, but it seemed straightforward enough...

Closes #76 