### PR TITLE
account for gametime drift

### DIFF
--- a/src/Helldivers-2-Core/Mapping/MappingContext.cs
+++ b/src/Helldivers-2-Core/Mapping/MappingContext.cs
@@ -1,0 +1,63 @@
+﻿using Helldivers.Models.ArrowHead;
+
+namespace Helldivers.Core.Mapping;
+
+/// <summary>
+/// Contains the context of the ArrowHead models currently being mapped.
+/// It's main purpose is to provide a convenient way to pass around <b>all</b> ArrowHead data
+/// at once without having to pass 7-8 parameters to each function (or when adding more data,
+/// having to update all dependent signatures).
+/// </summary>
+public sealed class MappingContext
+{
+    /// <summary>The <see cref="WarId" /> currently being mapped.</summary>
+    public WarId WarId { get; private init; }
+
+    /// <summary>The <see cref="WarInfo" /> currently being mapped.</summary>
+    public WarInfo WarInfo { get; private init; }
+
+    /// <summary>The <see cref="WarStatus" />es currently being mapped.</summary>
+    public Dictionary<string, WarStatus> WarStatuses { get; private init; }
+
+    /// <summary>A <see cref="WarStatus" /> that can be used when accessing non-localized data.</summary>
+    public WarStatus InvariantWarStatus { get; private init; }
+
+    /// <summary>The <see cref="WarSummary" /> currently being mapped.</summary>
+    public WarSummary WarSummary { get; private init; }
+
+    /// <summary>The <see cref="NewsFeedItem" />s currently being mapped.</summary>
+    public Dictionary<string, List<NewsFeedItem>> NewsFeeds { get; private init; }
+
+    /// <summary>The <see cref="Assignment" />s currently being mapped.</summary>
+    public Dictionary<string, List<Assignment>> Assignments { get; private init; }
+
+    /// <summary>
+    /// A <see cref="DateTime" /> that represents the 'start' of the time in Helldivers 2.
+    /// This accounts for the <see cref="Models.ArrowHead.WarInfo.StartDate" /> and <see cref="GameTimeDeviation" />.
+    /// </summary>
+    public DateTime RelativeGameStart { get; private init; }
+
+    /// <summary>
+    /// There's a deviation between gametime and real world time.
+    /// When calculating dates using ArrowHead timestamps, add this to compensate for the deviation.
+    /// </summary>
+    public TimeSpan GameTimeDeviation { get; private init; }
+
+    /// <summary>Initializes a new <see cref="MappingContext" />.</summary>
+    internal MappingContext(WarId warId, WarInfo warInfo, Dictionary<string, WarStatus> warStatuses, WarSummary warSummary, Dictionary<string, List<NewsFeedItem>> newsFeeds, Dictionary<string, List<Assignment>> assignments)
+    {
+        WarId = warId;
+        WarInfo = warInfo;
+        WarStatuses = warStatuses;
+        WarSummary = warSummary;
+        NewsFeeds = newsFeeds;
+        Assignments = assignments;
+
+        InvariantWarStatus = warStatuses.FirstOrDefault().Value
+                             ?? throw new InvalidOperationException("No warstatus available");
+
+        var gameTime = DateTime.UnixEpoch.AddSeconds(warInfo.StartDate + InvariantWarStatus.Time);
+        GameTimeDeviation = DateTime.UtcNow.Subtract(gameTime);
+        RelativeGameStart = DateTime.UnixEpoch.Add(GameTimeDeviation).AddSeconds(warInfo.StartDate);
+    }
+}

--- a/src/Helldivers-2-Core/Mapping/V1/AssignmentMapper.cs
+++ b/src/Helldivers-2-Core/Mapping/V1/AssignmentMapper.cs
@@ -13,17 +13,17 @@ public sealed class AssignmentMapper
     /// <summary>
     /// Maps a set of multi-language <see cref="Assignment" />s into a list of <see cref="Assignment" />.
     /// </summary>
-    public IEnumerable<Assignment> MapToV1(Dictionary<string, List<Models.ArrowHead.Assignment>> assignments)
+    public IEnumerable<Assignment> MapToV1(MappingContext context)
     {
         // Get a list of all assignments across all translations.
-        var invariants = assignments
+        var invariants = context.Assignments
             .SelectMany(pair => pair.Value)
             .DistinctBy(assignment => assignment.Id32);
 
         foreach (var assignment in invariants)
         {
             // Build a dictionary of all translations for this assignment
-            var translations = assignments.Select(pair =>
+            var translations = context.Assignments.Select(pair =>
                 new KeyValuePair<string, Models.ArrowHead.Assignment?>(
                     pair.Key,
                     pair.Value.FirstOrDefault(a => a.Id32 == assignment.Id32)

--- a/src/Helldivers-2-Core/Mapping/V1/CampaignMapper.cs
+++ b/src/Helldivers-2-Core/Mapping/V1/CampaignMapper.cs
@@ -8,9 +8,18 @@ namespace Helldivers.Core.Mapping.V1;
 public class CampaignMapper
 {
     /// <summary>
+    /// Maps all <see cref="Campaign" /> in the current context. 
+    /// </summary>
+    public IEnumerable<Campaign> MapToV1(MappingContext context, List<Planet> planets)
+    {
+        foreach (var campaign in context.InvariantWarStatus.Campaigns)
+            yield return MapToV1(campaign, planets);
+    }
+
+    /// <summary>
     /// Maps ArrowHead's <see cref="Models.ArrowHead.Status.Campaign" /> onto V1's.
     /// </summary>
-    public Campaign MapToV1(Models.ArrowHead.Status.Campaign campaign, List<Planet> planets)
+    private Campaign MapToV1(Models.ArrowHead.Status.Campaign campaign, List<Planet> planets)
     {
         var planet = planets.First(p => p.Index == campaign.PlanetIndex);
 

--- a/src/Helldivers-2-Core/Mapping/V1/DispatchMapper.cs
+++ b/src/Helldivers-2-Core/Mapping/V1/DispatchMapper.cs
@@ -12,17 +12,17 @@ public sealed class DispatchMapper
     /// <summary>
     /// Maps ArrowHead's <see cref="WarInfo" /> onto V1's <see cref="Dispatch" />es.
     /// </summary>
-    public IEnumerable<Dispatch> MapToV1(WarInfo info, Dictionary<string, List<NewsFeedItem>> items)
+    public IEnumerable<Dispatch> MapToV1(MappingContext context)
     {
         // Get a list of all items across all translations.
-        var invariants = items
+        var invariants = context.NewsFeeds
             .SelectMany(pair => pair.Value)
             .DistinctBy(assignment => assignment.Id);
 
         foreach (var item in invariants)
         {
             // Build a dictionary of all translations for this item
-            var translations = items.Select(pair =>
+            var translations = context.NewsFeeds.Select(pair =>
                 new KeyValuePair<string, NewsFeedItem?>(
                     pair.Key,
                     pair.Value.FirstOrDefault(a => a.Id == item.Id)
@@ -30,18 +30,18 @@ public sealed class DispatchMapper
             ).Where(pair => pair.Value is not null)
             .ToDictionary(pair => pair.Key, pair => pair.Value!);
 
-            yield return MapToV1(info, translations);
+            yield return MapToV1(context, translations);
         }
     }
 
-    private Dispatch MapToV1(WarInfo info, Dictionary<string, NewsFeedItem> translations)
+    private Dispatch MapToV1(MappingContext context, Dictionary<string, NewsFeedItem> translations)
     {
         var invariant = translations.Values.First();
         var messages = translations.Select(pair => new KeyValuePair<string, string>(pair.Key, pair.Value.Message));
 
         return new Dispatch(
             Id: invariant.Id,
-            Published: DateTime.UnixEpoch.AddSeconds(info.StartDate + invariant.Published),
+            Published: context.RelativeGameStart.AddSeconds(invariant.Published),
             Type: invariant.Type,
             Message: LocalizedMessage.FromStrings(messages)
         );

--- a/src/Helldivers-2-Core/Mapping/V1/PlanetMapper.cs
+++ b/src/Helldivers-2-Core/Mapping/V1/PlanetMapper.cs
@@ -14,7 +14,7 @@ public sealed class PlanetMapper(StatisticsMapper statisticsMapper)
 {
     /// <summary>
     /// Maps all planet information into a list of <see cref="Planet" /> objects.
-    /// see <see cref="MapToV1(PlanetInfo, PlanetStatus, PlanetEvent, PlanetStats, List{int})" />
+    /// see <see cref="MapToV1(MappingContext, PlanetInfo, PlanetStatus, PlanetEvent, PlanetStats, List{int})" />
     /// </summary>
     public IEnumerable<Planet> MapToV1(MappingContext context)
     {

--- a/src/Helldivers-2-Core/Mapping/V1/WarMapper.cs
+++ b/src/Helldivers-2-Core/Mapping/V1/WarMapper.cs
@@ -1,5 +1,4 @@
 ﻿using Helldivers.Models;
-using Helldivers.Models.ArrowHead;
 using Helldivers.Models.V1;
 
 namespace Helldivers.Core.Mapping.V1;
@@ -12,16 +11,16 @@ public sealed class WarMapper(StatisticsMapper statisticsMapper)
     /// <summary>
     /// Handles mapping <see cref="War" /> to V1.
     /// </summary>
-    public War MapToV1(WarInfo info, WarStatus status, WarSummary summary, List<Planet> planets)
+    public War MapToV1(MappingContext context, List<Planet> planets)
     {
         return new War(
-            Started: DateTime.UnixEpoch.AddSeconds(info.StartDate),
-            Ended: DateTime.UnixEpoch.AddSeconds(info.EndDate),
-            Now: DateTime.UnixEpoch.AddSeconds(status.Time),
-            ClientVersion: info.MinimumClientVersion,
+            Started: DateTime.UnixEpoch.AddSeconds(context.WarInfo.StartDate),
+            Ended: DateTime.UnixEpoch.AddSeconds(context.WarInfo.EndDate),
+            Now: DateTime.UnixEpoch.AddSeconds(context.InvariantWarStatus.Time),
+            ClientVersion: context.WarInfo.MinimumClientVersion,
             Factions: Static.Factions.Values.ToList(),
-            ImpactMultiplier: status.ImpactMultiplier,
-            Statistics: statisticsMapper.MapToV1(summary.GalaxyStats, planets)
+            ImpactMultiplier: context.InvariantWarStatus.ImpactMultiplier,
+            Statistics: statisticsMapper.MapToV1(context.WarSummary.GalaxyStats, planets)
         );
     }
 }

--- a/src/Helldivers-2-Core/StorageFacade.cs
+++ b/src/Helldivers-2-Core/StorageFacade.cs
@@ -1,4 +1,5 @@
 ﻿using Helldivers.Core.Facades;
+using Helldivers.Core.Mapping;
 using Helldivers.Core.Storage.ArrowHead;
 using Helldivers.Models;
 using Helldivers.Models.Steam;
@@ -51,7 +52,7 @@ public sealed class StorageFacade(ArrowHeadStore arrowHead, SteamFacade steam, V
             pair => DeserializeOrThrow(pair.Value, ArrowHeadSerializerContext.Default.ListAssignment)
         );
 
-        await v1.UpdateStores(
+        var context = new MappingContext(
             warId,
             warInfo,
             warStatuses,
@@ -59,6 +60,8 @@ public sealed class StorageFacade(ArrowHeadStore arrowHead, SteamFacade steam, V
             newsFeeds,
             assignments
         );
+
+        await v1.UpdateStores(context);
     }
 
     private T DeserializeOrThrow<T>(Memory<byte> memory, JsonTypeInfo<T> typeInfo)


### PR DESCRIPTION
see #78
see #21

problem ended up being that the dates reported by the planet events and newsfeed are relative to the in-game time (`WarInfo.StartDate` and `WarStatus.Time`), however there's approximately 18 days deviation to 'real world' time (at the time of writing).

This patch introduces a `MappingContext` which, aside from cleaning up mapping code, also has `RelativeGameStart` and `GameTimeDeviation` properties for dealing with dates that are relative in-game.