### PR TITLE
Feature/rate limits

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
         This form is only for submitting bug reports. If you have a usage question
         or are unsure if this is really a bug, make sure to:
 
-        - Read the [docs](https://helldivers-2.fly.dev/swagger-ui.html)
+        - Read the [docs](https://helldivers-2.github.io/api/)
         - Ask on [Discord Chat](https://discord.gg/E8UUfWYmf9)
         - Ask on [GitHub Discussions](https://github.com/helldivers-2/api/discussions)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ a [SwaggerUI](https://helldivers-2.github.io/api/docs/openapi/swagger-ui.html) (
 internally, however we strongly encourage you to use the `/raw` endpoints of the community wrapper instead of accessing
 the ArrowHead API directly, as it puts additional load on their servers (besides, we have shinier endpoints, I swear!).
 
-The root URL of the API is available here: https://helldivers-2.elixus.be
+The root URL of the API is available here: https://api.helldivers2.dev
 > [!WARNING]
 > The root domain of the API recently changed, it's recommended you use the domain above to avoid problems in the future
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ a [SwaggerUI](https://helldivers-2.github.io/api/docs/openapi/swagger-ui.html) (
 internally, however we strongly encourage you to use the `/raw` endpoints of the community wrapper instead of accessing
 the ArrowHead API directly, as it puts additional load on their servers (besides, we have shinier endpoints, I swear!).
 
-The root URL of the API is available here: https://helldivers-2-dotnet.fly.dev/
+The root URL of the API is available here: https://helldivers-2.elixus.be
 > [!WARNING]
-> Note that it might change as we are transitioning from the Elixir version to a new version!
+> The root domain of the API recently changed, it's recommended you use the domain above to avoid problems in the future
 
 We also ask that you send us a `User-Agent` header when making requests (if accessing directly from the browser,
 the headers sent by those should suffice and you don't need to add anything special).

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -62,3 +62,26 @@ docker run -p 8080:8080 -e "Helldivers__Synchronization__IntervalSeconds=10" hel
 ```
 
 You can read more about using environment variables to override configuration [here](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0#naming-of-environment-variables)
+
+### Overriding rate limits
+You can override the rate limits by overriding the following configuration:
+```json
+{
+  "Helldivers": {
+    "API": {
+      "RateLimit": 5,
+      "RateLimitWindow": 10
+    }
+  }
+}
+```
+
+The `RateLimit` (overridable with `-e Helldivers__API__RateLimit`) is how many requests can be made in the timeframe,
+the `RateLimitWindow` (overridable with `-e Helldivers__API__RateLimitWindow`) is how many seconds before the `RateLimit`
+resets again.
+
+Increasing the `RateLimit`, decreasing the `RateLimitWindow` or both will effectively increase how many requests you can
+make to the application.
+
+Alternatively, if you use the hosted versions you can request an API key that allows for higher rate limits
+by sponsoring this project! (if you self host you can generate your own keys too!).

--- a/src/Helldivers-2-API/Configuration/ApiConfiguration.cs
+++ b/src/Helldivers-2-API/Configuration/ApiConfiguration.cs
@@ -1,0 +1,12 @@
+﻿namespace Helldivers.API.Configuration;
+
+/// <summary>
+/// Contains configuration of the API.
+/// </summary>
+public sealed class ApiConfiguration
+{
+    /// <summary>
+    /// Contains the <see cref="AuthenticationConfiguration" /> for the API.
+    /// </summary>
+    public AuthenticationConfiguration Authentication { get; set; } = null!;
+}

--- a/src/Helldivers-2-API/Configuration/ApiConfiguration.cs
+++ b/src/Helldivers-2-API/Configuration/ApiConfiguration.cs
@@ -6,6 +6,16 @@
 public sealed class ApiConfiguration
 {
     /// <summary>
+    /// The amount of requests that can be made within the time limit.
+    /// </summary>
+    public int RateLimit { get; set; }
+
+    /// <summary>
+    /// The time before the rate limit resets (in seconds).
+    /// </summary>
+    public int RateLimitWindow { get; set; }
+
+    /// <summary>
     /// Contains the <see cref="AuthenticationConfiguration" /> for the API.
     /// </summary>
     public AuthenticationConfiguration Authentication { get; set; } = null!;

--- a/src/Helldivers-2-API/Configuration/AuthenticationConfiguration.cs
+++ b/src/Helldivers-2-API/Configuration/AuthenticationConfiguration.cs
@@ -1,0 +1,22 @@
+﻿namespace Helldivers.API.Configuration;
+
+/// <summary>
+/// Contains configuration for the authentication functionality of the API.
+/// </summary>
+public sealed class AuthenticationConfiguration
+{
+    /// <summary>
+    /// A list of valid issuers of authentication tokens.
+    /// </summary>
+    public List<string> ValidIssuers { get; set; } = [];
+
+    /// <summary>
+    /// A list of valid audiences for said authentication tokens.
+    /// </summary>
+    public List<string> ValidAudiences { get; set; } = [];
+
+    /// <summary>
+    /// A string containing a base64 encoded secret used for signing and verifying authentication tokens.
+    /// </summary>
+    public string SigningKey { get; set; } = null!;
+}

--- a/src/Helldivers-2-API/Controllers/DevelopmentController.cs
+++ b/src/Helldivers-2-API/Controllers/DevelopmentController.cs
@@ -1,0 +1,40 @@
+﻿using Helldivers.API.Configuration;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace Helldivers.API.Controllers;
+
+/// <summary>
+/// Controller class that's only available in development, contains local debugging endpoints etc.
+/// </summary>
+public static class DevelopmentController
+{
+    private static readonly JwtSecurityTokenHandler TokenHandler = new();
+
+    /// <summary>
+    /// Creates a JWT token for the given <paramref name="name" /> and <paramref name="limit" />.
+    /// </summary>
+    public static IResult CreateToken([FromQuery] string name, [FromQuery] int limit, [FromServices] IOptions<ApiConfiguration> options)
+    {
+        var key = new SymmetricSecurityKey(Convert.FromBase64String(options.Value.Authentication.SigningKey));
+        var token = new JwtSecurityToken(
+            issuer: options.Value.Authentication.ValidIssuers.First(),
+            audience: options.Value.Authentication.ValidAudiences.First(),
+            claims: [
+                new Claim("sub", name),
+                new Claim("nbf", $"{DateTime.UtcNow.Subtract(DateTime.UnixEpoch).TotalSeconds:0}"),
+                new Claim("iat", $"{DateTime.UtcNow.Subtract(DateTime.UnixEpoch).TotalSeconds:0}"),
+                new Claim("exp", $"{DateTime.UtcNow.AddDays(30).Subtract(DateTime.UnixEpoch).TotalSeconds:0}"),
+                new Claim("RateLimit", $"{limit}")
+            ],
+            expires: DateTime.UtcNow.AddDays(30),
+            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256)
+        );
+
+        var jwt = TokenHandler.WriteToken(token);
+        return Results.Ok(jwt);
+    }
+}

--- a/src/Helldivers-2-API/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Helldivers-2-API/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Security.Claims;
+
+namespace Helldivers.API.Extensions;
+
+/// <summary>
+/// Contains extension methods for working with <see cref="ClaimsPrincipal" />s.
+/// </summary>
+public static class ClaimsPrincipalExtensions
+{
+    /// <summary>
+    /// Attempts to retrieve the integer value of a <see cref="Claim" /> with type <paramref name="type" />.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if the claim could not be found, or is not a valid integer.</exception>
+    public static int GetIntClaim(this ClaimsPrincipal user, string type)
+    {
+        var claim = user.Claims.FirstOrDefault(c =>
+            string.Equals(c.Type, type, StringComparison.InvariantCultureIgnoreCase));
+
+        if (claim is { Value: var str } && int.TryParse(str, out var result))
+            return result;
+
+        throw new InvalidOperationException($"Cannot fetch {type} or it is not a valid number");
+    }
+}

--- a/src/Helldivers-2-API/Helldivers-2-API.csproj
+++ b/src/Helldivers-2-API/Helldivers-2-API.csproj
@@ -6,7 +6,7 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
         <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-    </PropertyGroup>
+  </PropertyGroup>
 
     <!-- Only generate OpenAPI docs for DEBUG builds -->
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
@@ -23,23 +23,24 @@
 
     <!-- Dependencies for all build configurations -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1"/>
-        <ProjectReference Include="..\Helldivers-2-Models\Helldivers-2-Models.csproj"/>
-        <ProjectReference Include="..\Helldivers-2-Core\Helldivers-2-Core.csproj"/>
-        <ProjectReference Include="..\Helldivers-2-Sync\Helldivers-2-Sync.csproj"/>
-        <TrimmerRootAssembly Include="Helldivers-2-Models"/>
-        <TrimmerRootAssembly Include="Helldivers-2-Core"/>
-        <TrimmerRootAssembly Include="Helldivers-2-Sync"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+        <ProjectReference Include="..\Helldivers-2-Models\Helldivers-2-Models.csproj" />
+        <ProjectReference Include="..\Helldivers-2-Core\Helldivers-2-Core.csproj" />
+        <ProjectReference Include="..\Helldivers-2-Sync\Helldivers-2-Sync.csproj" />
+        <TrimmerRootAssembly Include="Helldivers-2-Models" />
+        <TrimmerRootAssembly Include="Helldivers-2-Core" />
+        <TrimmerRootAssembly Include="Helldivers-2-Sync" />
     </ItemGroup>
 
     <!-- Only include swagger dependencies in DEBUG builds -->
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
         <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="8.0.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NSwag.AspNetCore" Version="14.0.4"/>
+        <PackageReference Include="NSwag.AspNetCore" Version="14.0.4" />
     </ItemGroup>
 
 </Project>

--- a/src/Helldivers-2-API/OpenApi/DocumentProcessors/HelldiversDocumentProcessor.cs
+++ b/src/Helldivers-2-API/OpenApi/DocumentProcessors/HelldiversDocumentProcessor.cs
@@ -10,7 +10,7 @@ namespace Helldivers.API.OpenApi.DocumentProcessors;
 /// </summary>
 public class HelldiversDocumentProcessor : IDocumentProcessor
 {
-    private const string HelldiversFlyServer = "https://helldivers-2-dotnet.fly.dev/";
+    private const string HelldiversFlyServer = "https://helldivers-2.elixus.be/";
     private const string LocalServer = "/";
 
     /// <inheritdoc />

--- a/src/Helldivers-2-API/OpenApi/DocumentProcessors/HelldiversDocumentProcessor.cs
+++ b/src/Helldivers-2-API/OpenApi/DocumentProcessors/HelldiversDocumentProcessor.cs
@@ -10,7 +10,7 @@ namespace Helldivers.API.OpenApi.DocumentProcessors;
 /// </summary>
 public class HelldiversDocumentProcessor : IDocumentProcessor
 {
-    private const string HelldiversFlyServer = "https://helldivers-2.elixus.be/";
+    private const string HelldiversFlyServer = "https://api.helldivers2.dev/";
     private const string LocalServer = "/";
 
     /// <inheritdoc />

--- a/src/Helldivers-2-API/appsettings.Development.json
+++ b/src/Helldivers-2-API/appsettings.Development.json
@@ -8,6 +8,11 @@
     }
   },
   "Helldivers": {
+    "API": {
+      "Authentication": {
+        "SigningKey": "I4eGmsXbDXfxlRo5N+w0ToRGN8aWSIaYWbZ2zMFqqnI="
+      }
+    },
     "Synchronization": {
       "IntervalSeconds": 300,
       "DefaultLanguage": "en-US",

--- a/src/Helldivers-2-API/appsettings.json
+++ b/src/Helldivers-2-API/appsettings.json
@@ -4,11 +4,20 @@
       "Default": "Information",
       "Helldivers": "Trace",
       "System.Net.Http.HttpClient": "Warning",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.Authentication": "Trace"
     }
   },
   "AllowedHosts": "*",
   "Helldivers": {
+    "API": {
+      "Authentication": {
+        "ValidIssuers": ["dealloc"],
+        "ValidAudiences": [
+          "https://helldivers-2.elixus.be"
+        ]
+      }
+    },
     "Synchronization": {
       "IntervalSeconds": 20,
       "DefaultLanguage": "en-US",

--- a/src/Helldivers-2-API/appsettings.json
+++ b/src/Helldivers-2-API/appsettings.json
@@ -11,6 +11,8 @@
   "AllowedHosts": "*",
   "Helldivers": {
     "API": {
+      "RateLimit": 5,
+      "RateLimitWindow": 10,
       "Authentication": {
         "ValidIssuers": ["dealloc"],
         "ValidAudiences": [

--- a/src/Helldivers-2-API/appsettings.json
+++ b/src/Helldivers-2-API/appsettings.json
@@ -16,7 +16,7 @@
       "Authentication": {
         "ValidIssuers": ["dealloc"],
         "ValidAudiences": [
-          "https://helldivers-2.elixus.be"
+          "https://api.helldivers2.dev"
         ]
       }
     },


### PR DESCRIPTION
This pull request adds 2 new features:
- allow reconfiguring the rate limits through appsettings or environment variables, this allows self hosting users to set a custom rate limit
- allow passing a JWT token that overrides the configured rate limits

You can generate JWT tokens in development by hitting the `/dev/token` endpoint (endpoint is not available outside `DEBUG` environments).

Documentation has also been rudimentary updated to explain self hosting users to configure the rate limits.

Additionally, it also updates the documentation to refer users to `https://helldivers-2.elixus.be` so that if we ever rename the project or move away from Fly.io the URL wouldn't break all applications