### PR TITLE
fix: use type int for CampaignId

### DIFF
--- a/src/Helldivers-2-Models/ArrowHead/Status/PlanetEvent.cs
+++ b/src/Helldivers-2-Models/ArrowHead/Status/PlanetEvent.cs
@@ -24,6 +24,6 @@ public sealed record PlanetEvent(
     long MaxHealth,
     long StartTime,
     long ExpireTime,
-    long CampaignId,
+    int CampaignId,
     List<int> JointOperationIds
 );

--- a/src/Helldivers-2-Models/V1/Planets/Event.cs
+++ b/src/Helldivers-2-Models/V1/Planets/Event.cs
@@ -20,6 +20,6 @@ public sealed record Event(
     long MaxHealth,
     DateTime StartTime,
     DateTime EndTime,
-    long CampaignId,
+    int CampaignId,
     List<int> JointOperationIds
 );


### PR DESCRIPTION
Hope this is all that's required to change a field type, don't have a full-fletched dev setup for C# at the moment.

Closes #85.