### PR TITLE
export metrics to Prometheus

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,4 +5,8 @@
         <TargetFramework>net8.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="prometheus-net" Version="8.2.1" />
+    </ItemGroup>
 </Project>

--- a/fly.toml
+++ b/fly.toml
@@ -13,6 +13,10 @@ kill_signal = 'SIGTERM'
 
 [env]
 
+[metrics]
+port = 8080
+parth = "/metrics"
+
 [http_service]
   internal_port = 8080
   force_https = true

--- a/src/Helldivers-2-API/Helldivers-2-API.csproj
+++ b/src/Helldivers-2-API/Helldivers-2-API.csproj
@@ -25,6 +25,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+        <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
         <ProjectReference Include="..\Helldivers-2-Models\Helldivers-2-Models.csproj" />
         <ProjectReference Include="..\Helldivers-2-Core\Helldivers-2-Core.csproj" />
         <ProjectReference Include="..\Helldivers-2-Sync\Helldivers-2-Sync.csproj" />

--- a/src/Helldivers-2-API/Program.cs
+++ b/src/Helldivers-2-API/Program.cs
@@ -185,7 +185,14 @@ app.UseHttpMetrics(options =>
         if (context.User.Identity is { Name: { } name })
             return name;
 
-        return string.Empty;
+        // TODO: document custom header that clients can send to identify themselves.
+
+        if (string.IsNullOrWhiteSpace(context.Request.Headers.Referer) is false)
+            return context.Request.Headers.Referer!;
+        if (string.IsNullOrWhiteSpace(context.Request.Headers.Origin) is false)
+            return context.Request.Headers.Origin!;
+
+        return "Unknown";
     });
 });
 


### PR DESCRIPTION
this PR adds Prometheus metrics which provides additional metrics for Fly metrics.
The goal is to have more graphs and information on usage of the API

fix #84