### PR TITLE
Update fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -15,7 +15,7 @@ kill_signal = 'SIGTERM'
 
 [metrics]
 port = 8080
-parth = "/metrics"
+path = "/metrics"
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
Correct typo in `fly.toml` causing metrics to not index. The giveaway was `fly config show` not picking up on the metrics path
![image](https://github.com/helldivers-2/api/assets/2164354/186f538d-2018-4b97-bce3-e57ccc7a9a12)

I'd like to get this fix out ASAP
