### PR TITLE
metrics improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,15 @@ The root URL of the API is available here: https://api.helldivers2.dev
 > [!WARNING]
 > The root domain of the API recently changed, it's recommended you use the domain above to avoid problems in the future
 
-We also ask that you send us a `User-Agent` header when making requests (if accessing directly from the browser,
-the headers sent by those should suffice and you don't need to add anything special).
-While this is currently not *required*, we are considering making this required in the future, so adding it now
-is the safer option.
+We ask that you send along a `X-Super-Client` header with the name of your application / domain
+(e.g. `X-Super-Client: api.helldivers2.dev`) and optionally a `X-Super-Contact` with some form of contact if your site
+does not link to any form of contact information we can find. We use this information in case we need to notify our users
+of important changes to the API that may cause disruption of service or when additional restrictions would be imposed
+on your app (to prevent abuse, unintentional or otherwise).
 
-We also ask that you include an `X-Application-Contact` header with either a Discord, email or other contact handle
-so we know how to reach out to you (see below).
-
-We ask this so we can identify the applications making requests, and so we can reach out in case we notice weird or
-incorrect behaviour (or we notice you're generating more traffic than we can handle).
+> [!IMPORTANT]
+> While adding `X-Super-Client` and `X-Super-Contact` is currently not required, the `X-Super-Client` header **will**
+> be made obligatory in the future, causing clients who don't send it to fail. For more information see #94
 
 ### Rate limits
 Currently the rate limit is set at 5 requests/10 seconds.

--- a/src/Helldivers-2-API/Metrics/ClientMetric.cs
+++ b/src/Helldivers-2-API/Metrics/ClientMetric.cs
@@ -29,7 +29,10 @@ public static partial class ClientMetric
         if (context.User.Identity is { Name: { } name })
             return name;
 
-        // TODO: document custom header that clients can send to identify themselves.
+        // If the client sends `X-Super-Client` we use that name
+        if (context.Request.Headers.TryGetValue("X-Super-Client", out var superClient))
+            if (string.IsNullOrWhiteSpace(superClient) is false)
+                return superClient!;
 
         if (GetBrowserClientName(context.Request) is { } clientName)
             return clientName;

--- a/src/Helldivers-2-API/Metrics/ClientMetric.cs
+++ b/src/Helldivers-2-API/Metrics/ClientMetric.cs
@@ -1,0 +1,71 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Helldivers.API.Metrics;
+
+/// <summary>
+/// Handles the logic for generating the `Client` label in the Prometheus metrics for HTTP requests.
+/// </summary>
+public static partial class ClientMetric
+{
+    /// <summary>
+    /// The name of a client that couldn't be identified.
+    /// </summary>
+    private const string UNKNOWN_CLIENT_NAME = "Unknown";
+
+    /// <summary>
+    /// The name for clients that are developing locally (e.g. localhost, ...).
+    /// </summary>
+    private const string LOCAL_DEVELOPMENT_CLIENT_NAME = "Development";
+
+    [GeneratedRegex(@"^[a-z0-9]{24}--.+\.netlify\.app$")]
+    private static partial Regex IsNetlifyApp();
+
+    /// <summary>
+    /// Extracts the name of the client for the incoming request.
+    /// </summary>
+    public static string GetClientName(HttpContext context)
+    {
+        // If we have an authenticated user, use their name instead
+        if (context.User.Identity is { Name: { } name })
+            return name;
+
+        // TODO: document custom header that clients can send to identify themselves.
+
+        if (GetBrowserClientName(context.Request) is { } clientName)
+            return clientName;
+
+        return UNKNOWN_CLIENT_NAME;
+    }
+
+    /// <summary>
+    /// If the client is a browser it sends specific headers along.
+    /// Attempt to parse out those headers to get the domain and perform some additional normalization.
+    ///
+    /// If we can't find any of those headers simply return <c>null</c>
+    /// </summary>
+    private static string? GetBrowserClientName(HttpRequest request)
+    {
+        string? result = null;
+        if (string.IsNullOrWhiteSpace(request.Headers.Referer) is false)
+            result = request.Headers.Referer!;
+        if (string.IsNullOrWhiteSpace(request.Headers.Origin) is false)
+            result = request.Headers.Origin!;
+
+        if (result is not null && Uri.TryCreate(result, UriKind.Absolute, out var uri))
+        {
+            // Localhost etc just return local development for a client name.
+            if (uri.Host.Equals("localhost", StringComparison.InvariantCultureIgnoreCase))
+                return LOCAL_DEVELOPMENT_CLIENT_NAME;
+
+            // Netlify seems to generate urls with random prefixes like following:
+            // <24 characters random>--<projectname>.netlify.app
+            // we normalize to <projectname>.netlify.app
+            if (IsNetlifyApp().IsMatch(uri.Host))
+                return uri.Host[26..];
+
+            return uri.Host;
+        }
+
+        return result;
+    }
+}

--- a/src/Helldivers-2-API/Middlewares/RedirectFlyDomainMiddleware.cs
+++ b/src/Helldivers-2-API/Middlewares/RedirectFlyDomainMiddleware.cs
@@ -1,0 +1,22 @@
+﻿namespace Helldivers.API.Middlewares;
+
+/// <summary>
+/// Automatically generates a redirect if a user still uses the deprecated `fly.io` URL.
+/// </summary>
+public class RedirectFlyDomainMiddleware : IMiddleware
+{
+    private const string RedirectDomain = "https://api.helldivers2.dev";
+
+    /// <inheritdoc />
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        if (context.Request.Host.Host.Equals("helldivers-2-dotnet.fly.dev", StringComparison.InvariantCultureIgnoreCase))
+        {
+            var url = $"{RedirectDomain}{context.Request.Path}";
+            
+            context.Response.Redirect(url, permanent: true);
+        }
+
+        await next(context);
+    }
+}

--- a/src/Helldivers-2-API/Middlewares/RedirectFlyDomainMiddleware.cs
+++ b/src/Helldivers-2-API/Middlewares/RedirectFlyDomainMiddleware.cs
@@ -13,7 +13,7 @@ public class RedirectFlyDomainMiddleware : IMiddleware
         if (context.Request.Host.Host.Equals("helldivers-2-dotnet.fly.dev", StringComparison.InvariantCultureIgnoreCase))
         {
             var url = $"{RedirectDomain}{context.Request.Path}";
-            
+
             context.Response.Redirect(url, permanent: true);
         }
 

--- a/src/Helldivers-2-API/Program.cs
+++ b/src/Helldivers-2-API/Program.cs
@@ -1,6 +1,7 @@
 using Helldivers.API.Configuration;
 using Helldivers.API.Controllers;
 using Helldivers.API.Controllers.V1;
+using Helldivers.API.Metrics;
 using Helldivers.API.Middlewares;
 using Helldivers.Core.Extensions;
 using Helldivers.Models;
@@ -184,20 +185,7 @@ var app = builder.Build();
 // Track telemetry for Prometheus (Fly.io metrics)
 app.UseHttpMetrics(options =>
 {
-    options.AddCustomLabel("Client", context =>
-    {
-        if (context.User.Identity is { Name: { } name })
-            return name;
-
-        // TODO: document custom header that clients can send to identify themselves.
-
-        if (string.IsNullOrWhiteSpace(context.Request.Headers.Referer) is false)
-            return context.Request.Headers.Referer!;
-        if (string.IsNullOrWhiteSpace(context.Request.Headers.Origin) is false)
-            return context.Request.Headers.Origin!;
-
-        return "Unknown";
-    });
+    options.AddCustomLabel("Client", ClientMetric.GetClientName);
 });
 
 // Use response compression for smaller payload sizes

--- a/src/Helldivers-2-API/Program.cs
+++ b/src/Helldivers-2-API/Program.cs
@@ -43,6 +43,7 @@ builder.Services.AddProblemDetails();
 
 // Register the rate limiting middleware.
 builder.Services.AddTransient<RateLimitMiddleware>();
+builder.Services.AddTransient<RedirectFlyDomainMiddleware>();
 
 // Register the memory cache, used in the rate limiting middleware.
 builder.Services.AddMemoryCache();
@@ -181,6 +182,8 @@ builder.Services.AddHelldiversSync();
 #endif
 
 var app = builder.Build();
+
+app.UseMiddleware<RedirectFlyDomainMiddleware>();
 
 // Track telemetry for Prometheus (Fly.io metrics)
 app.UseHttpMetrics(options =>

--- a/src/Helldivers-2-Sync/Hosted/ArrowHeadSyncService.cs
+++ b/src/Helldivers-2-Sync/Hosted/ArrowHeadSyncService.cs
@@ -22,8 +22,8 @@ public sealed partial class ArrowHeadSyncService(
     StorageFacade storage
 ) : BackgroundService
 {
-    private static readonly Histogram SteamSyncMetric =
-        Metrics.CreateHistogram("helldivers_sync_steam", "All Steam synchronizations");
+    private static readonly Histogram ArrowHeadSyncMetric =
+        Metrics.CreateHistogram("helldivers_sync_arrowhead", "All ArrowHead synchronizations");
 
     #region Source generated logging
 
@@ -49,7 +49,7 @@ public sealed partial class ArrowHeadSyncService(
         {
             try
             {
-                using var _ = SteamSyncMetric.NewTimer();
+                using var _ = ArrowHeadSyncMetric.NewTimer();
                 await using var scope = scopeFactory.CreateAsyncScope();
 
                 await SynchronizeAsync(scope.ServiceProvider, cancellationToken);

--- a/src/Helldivers-2-Sync/Hosted/SteamSyncService.cs
+++ b/src/Helldivers-2-Sync/Hosted/SteamSyncService.cs
@@ -16,8 +16,8 @@ public sealed partial class SteamSyncService(
     IServiceScopeFactory scopeFactory
 ) : BackgroundService
 {
-    private static readonly Histogram ArrowHeadSyncMetric =
-        Metrics.CreateHistogram("helldivers_sync_arrowhead", "All ArrowHead synchronizations");
+    private static readonly Histogram SteamSyncMetric =
+        Metrics.CreateHistogram("helldivers_sync_steam", "All Steam synchronizations");
 
     #region Source generated logging
 
@@ -35,7 +35,7 @@ public sealed partial class SteamSyncService(
         {
             try
             {
-                using var _ = ArrowHeadSyncMetric.NewTimer();
+                using var _ = SteamSyncMetric.NewTimer();
                 await using var scope = scopeFactory.CreateAsyncScope();
 
                 var feed = await scope

--- a/src/Helldivers-2-Sync/Services/ArrowHeadApiService.cs
+++ b/src/Helldivers-2-Sync/Services/ArrowHeadApiService.cs
@@ -3,7 +3,6 @@ using Helldivers.Models.ArrowHead;
 using Helldivers.Sync.Configuration;
 using Microsoft.Extensions.Options;
 using System.Net.Http.Headers;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 
 namespace Helldivers.Sync.Services;


### PR DESCRIPTION
this PR expands the metrics implemented in #87 

It adds normalization for the Client name that is currently exported, as Prometheus currently reports things like this:
![image](https://github.com/helldivers-2/api/assets/2164354/bad7811b-da99-46fc-8b87-228514e10157)

note that it contains duplicate domains (like `divers.gg`) because it also records the path, and `heckdivers` has multiple Netlify URLS, these all get normalized and aggregated in proper client names.

It also documents and adds support for the `X-Super-Client` header that clients should start sending ASAP (we'll be providing PR for most developers we can identify and find GH for) to further improve client detection in the future.

This is the first PR towards #94 