### PR TITLE
implements a blacklist for clients that violate ToS

### DIFF
--- a/src/Helldivers-2-API/Configuration/ApiConfiguration.cs
+++ b/src/Helldivers-2-API/Configuration/ApiConfiguration.cs
@@ -16,6 +16,11 @@ public sealed class ApiConfiguration
     public int RateLimitWindow { get; set; }
 
     /// <summary>
+    /// A comma separated list of clients that are (temporarily) blacklisted from making requests.
+    /// </summary>
+    public string Blacklist { get; set; } = string.Empty;
+
+    /// <summary>
     /// Contains the <see cref="AuthenticationConfiguration" /> for the API.
     /// </summary>
     public AuthenticationConfiguration Authentication { get; set; } = null!;

--- a/src/Helldivers-2-API/Middlewares/BlacklistMiddleware.cs
+++ b/src/Helldivers-2-API/Middlewares/BlacklistMiddleware.cs
@@ -1,0 +1,25 @@
+﻿using Helldivers.API.Configuration;
+using Helldivers.API.Metrics;
+using Microsoft.Extensions.Options;
+
+namespace Helldivers.API.Middlewares;
+
+/// <summary>
+/// Handles closing connections from blacklisted clients that violate ToS.
+/// </summary>
+public sealed class BlacklistMiddleware(IOptions<ApiConfiguration> options) : IMiddleware
+{
+    /// <inheritdoc />
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        var client = ClientMetric.GetClientName(context);
+        if (options.Value.Blacklist.Contains(client, StringComparison.InvariantCultureIgnoreCase))
+        {
+            // don't send response, only wastes more bytes.
+            context.Abort();
+            return;
+        }
+
+        await next(context);
+    }
+}

--- a/src/Helldivers-2-API/Program.cs
+++ b/src/Helldivers-2-API/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddProblemDetails();
 // Register the rate limiting middleware.
 builder.Services.AddTransient<RateLimitMiddleware>();
 builder.Services.AddTransient<RedirectFlyDomainMiddleware>();
+builder.Services.AddTransient<BlacklistMiddleware>();
 
 // Register the memory cache, used in the rate limiting middleware.
 builder.Services.AddMemoryCache();
@@ -186,6 +187,7 @@ builder.Services.AddHelldiversSync();
 var app = builder.Build();
 
 app.UseMiddleware<RedirectFlyDomainMiddleware>();
+app.UseMiddleware<BlacklistMiddleware>();
 
 // Track telemetry for Prometheus (Fly.io metrics)
 app.UseHttpMetrics(options =>

--- a/src/Helldivers-2-API/appsettings.json
+++ b/src/Helldivers-2-API/appsettings.json
@@ -12,6 +12,7 @@
     "API": {
       "RateLimit": 5,
       "RateLimitWindow": 10,
+      "Blacklist": "",
       "Authentication": {
         "Enabled": true,
         "ValidIssuers": ["dealloc"],


### PR DESCRIPTION
this PR implements a blacklist, as the API is currently being hit very hard by a client violating ToS.

Configuration of the blacklist for the hosted version happens on Fly itself