### PR TITLE
fix ArrowHead numbers exceeding int32 mappings

### DIFF
--- a/src/Helldivers-2-API/Controllers/DevelopmentController.cs
+++ b/src/Helldivers-2-API/Controllers/DevelopmentController.cs
@@ -25,6 +25,7 @@ public static class DevelopmentController
             audience: options.Value.Authentication.ValidAudiences.First(),
             claims: [
                 new Claim("sub", name),
+                new Claim(ClaimTypes.Name, name),
                 new Claim("nbf", $"{DateTime.UtcNow.Subtract(DateTime.UnixEpoch).TotalSeconds:0}"),
                 new Claim("iat", $"{DateTime.UtcNow.Subtract(DateTime.UnixEpoch).TotalSeconds:0}"),
                 new Claim("exp", $"{DateTime.UtcNow.AddDays(30).Subtract(DateTime.UnixEpoch).TotalSeconds:0}"),

--- a/src/Helldivers-2-Models/ArrowHead/Assignment.cs
+++ b/src/Helldivers-2-Models/ArrowHead/Assignment.cs
@@ -11,7 +11,7 @@ namespace Helldivers.Models.ArrowHead;
 /// <param name="Setting">Contains detailed information on this assignment like briefing, rewards, ...</param>
 public sealed record Assignment(
     long Id32,
-    List<int> Progress,
+    List<ulong> Progress,
     long ExpiresIn,
     Setting Setting
 );

--- a/src/Helldivers-2-Models/ArrowHead/Assignments/Reward.cs
+++ b/src/Helldivers-2-Models/ArrowHead/Assignments/Reward.cs
@@ -8,6 +8,6 @@
 /// <param name="Amount">The amount of <see cref="Type" /> the players will receive upon completion.</param>
 public sealed record Reward(
     int Type,
-    int Id32,
-    int Amount
+    ulong Id32,
+    ulong Amount
 );

--- a/src/Helldivers-2-Models/ArrowHead/Assignments/Task.cs
+++ b/src/Helldivers-2-Models/ArrowHead/Assignments/Task.cs
@@ -9,6 +9,6 @@
 /// <param name="ValueTypes">A list of numerical values, purpose unknown.</param>
 public sealed record Task(
     int Type,
-    List<int> Values,
-    List<int> ValueTypes
+    List<ulong> Values,
+    List<ulong> ValueTypes
 );

--- a/src/Helldivers-2-Models/ArrowHead/Status/Campaign.cs
+++ b/src/Helldivers-2-Models/ArrowHead/Status/Campaign.cs
@@ -11,5 +11,5 @@ public sealed record Campaign(
     int Id,
     int PlanetIndex,
     int Type,
-    int Count
+    ulong Count
 );

--- a/src/Helldivers-2-Models/V1/Assignment.cs
+++ b/src/Helldivers-2-Models/V1/Assignment.cs
@@ -18,7 +18,7 @@ namespace Helldivers.Models.V1;
 /// <param name="Expiration">The date when the assignment will expire.</param>
 public sealed record Assignment(
     long Id,
-    List<int> Progress,
+    List<ulong> Progress,
     LocalizedMessage Title,
     LocalizedMessage Briefing,
     LocalizedMessage Description,

--- a/src/Helldivers-2-Models/V1/Assignments/Reward.cs
+++ b/src/Helldivers-2-Models/V1/Assignments/Reward.cs
@@ -7,5 +7,5 @@
 /// <param name="Amount">The amount of <see cref="Type" /> that will be awarded.</param>
 public sealed record Reward(
     int Type, // TODO: map to enum
-    int Amount
+    ulong Amount
 );

--- a/src/Helldivers-2-Models/V1/Assignments/Task.cs
+++ b/src/Helldivers-2-Models/V1/Assignments/Task.cs
@@ -9,6 +9,6 @@
 /// <param name="ValueTypes">A list of numbers, purpose unknown</param>
 public sealed record Task(
     int Type,
-    List<int> Values,
-    List<int> ValueTypes
+    List<ulong> Values,
+    List<ulong> ValueTypes
 );

--- a/src/Helldivers-2-Models/V1/Campaign.cs
+++ b/src/Helldivers-2-Models/V1/Campaign.cs
@@ -11,5 +11,5 @@ public record Campaign(
     int Id,
     Planet Planet,
     int Type, // TODO: map to enum
-    int Count
+    ulong Count
 );


### PR DESCRIPTION
fixes current Major Order not being able to be parsed due to numbers being out of bounds