### PR TITLE
add support for negative progress

### DIFF
--- a/src/Helldivers-2-Models/ArrowHead/Assignment.cs
+++ b/src/Helldivers-2-Models/ArrowHead/Assignment.cs
@@ -11,7 +11,7 @@ namespace Helldivers.Models.ArrowHead;
 /// <param name="Setting">Contains detailed information on this assignment like briefing, rewards, ...</param>
 public sealed record Assignment(
     long Id32,
-    List<ulong> Progress,
+    List<long> Progress,
     long ExpiresIn,
     Setting Setting
 );

--- a/src/Helldivers-2-Models/V1/Assignment.cs
+++ b/src/Helldivers-2-Models/V1/Assignment.cs
@@ -18,7 +18,7 @@ namespace Helldivers.Models.V1;
 /// <param name="Expiration">The date when the assignment will expire.</param>
 public sealed record Assignment(
     long Id,
-    List<ulong> Progress,
+    List<long> Progress,
     LocalizedMessage Title,
     LocalizedMessage Briefing,
     LocalizedMessage Description,


### PR DESCRIPTION
ArrowHead now occasionally pushes negative progress for assignments.
Since so far this hadn't happened we used `ulong` for tracking and this started causing crashes