### PR TITLE
Add headers to health check in fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -37,6 +37,10 @@ path = "/metrics"
     method = "GET"
     timeout = "10s"
     path = "/raw/api/WarSeason/current/WarID"
+    [http_service.checks.headers]
+      X-Super-Client = "Fly Health Check"
+      X-Super-Contact = "fly.io"
+
 
 
 [[vm]]


### PR DESCRIPTION
Included headers `X-Super-Client` and `X-Super-Contact` in the health check configuration. This ensures the health check requests are properly identified and can be managed accordingly.

Fly runs a health check on the HTTP endpoint when deploying, however after #114 every request without the `X-Super-*` headers failed causing health checks to fail (and thus also the deployment).

this is already deployed manually to maintain uptime, but to avoid future deploys breaking again there's this PR