### PR TITLE
Add SuperHeadersProcessor to OpenApi

### DIFF
--- a/Helldivers-2.sln
+++ b/Helldivers-2.sln
@@ -50,6 +50,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Templates", "Templates", "{
 		.github\ISSUE_TEMPLATE\feature_request.md = .github\ISSUE_TEMPLATE\feature_request.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OpenApi", "OpenApi", "{1A2CFD82-2D8E-4DA3-97A3-403BB478B6EB}"
+	ProjectSection(SolutionItems) = preProject
+		docs\openapi\Helldivers-2-API.json = docs\openapi\Helldivers-2-API.json
+		docs\openapi\Helldivers-2-API_arrowhead.json = docs\openapi\Helldivers-2-API_arrowhead.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -91,5 +97,6 @@ Global
 		{18D4A0EA-02CE-4FEA-A641-848A13603040} = {C0ECDBEB-FC7B-4F3C-AF8F-D0961BD22F61}
 		{9D663AC9-2CD8-4114-A802-D12284662FF0} = {18D4A0EA-02CE-4FEA-A641-848A13603040}
 		{FD5B9284-4689-48BE-B520-633C7269F97C} = {18D4A0EA-02CE-4FEA-A641-848A13603040}
+		{1A2CFD82-2D8E-4DA3-97A3-403BB478B6EB} = {C0ECDBEB-FC7B-4F3C-AF8F-D0961BD22F61}
 	EndGlobalSection
 EndGlobal

--- a/src/Helldivers-2-API/OpenApi/OperationProcessors/SuperHeadersProcessor.cs
+++ b/src/Helldivers-2-API/OpenApi/OperationProcessors/SuperHeadersProcessor.cs
@@ -1,0 +1,42 @@
+using NSwag;
+using NSwag.Generation.Processors;
+using NSwag.Generation.Processors.Contexts;
+
+namespace Helldivers.API.OpenApi.OperationProcessors;
+
+/// <summary>
+/// The <see cref="SuperHeadersProcessor"/> is used to add headers that are required for the API to identify
+/// the client and to provide developer contact information.
+/// </summary>
+public class SuperHeadersProcessor : IOperationProcessor
+{
+    /// <inheritdoc />
+    public bool Process(OperationProcessorContext context)
+    {
+        context.OperationDescription.Operation.Parameters.Add(
+            new OpenApiParameter
+            {
+                Name = Constants.CLIENT_HEADER_NAME,
+                Kind = OpenApiParameterKind.Header,
+                Type = NJsonSchema.JsonObjectType.String,
+                IsRequired = true,
+                Description = "The name of the header that identifies the client to the API.",
+                Default = string.Empty
+            }
+        );
+
+        context.OperationDescription.Operation.Parameters.Add(
+            new OpenApiParameter
+            {
+                Name = Constants.CONTACT_HEADER_NAME,
+                Kind = OpenApiParameterKind.Header,
+                Type = NJsonSchema.JsonObjectType.String,
+                IsRequired = true,
+                Description = "The name of the header with developer contact information.",
+                Default = string.Empty
+            }
+        );
+
+        return true;
+    }
+}

--- a/src/Helldivers-2-API/Program.cs
+++ b/src/Helldivers-2-API/Program.cs
@@ -4,6 +4,7 @@ using Helldivers.API.Controllers;
 using Helldivers.API.Controllers.V1;
 using Helldivers.API.Metrics;
 using Helldivers.API.Middlewares;
+using Helldivers.API.OpenApi.OperationProcessors;
 using Helldivers.Core.Extensions;
 using Helldivers.Models;
 using Helldivers.Models.Domain.Localization;
@@ -161,6 +162,8 @@ if (isRunningAsTool)
         document.SchemaSettings.TypeMappers.Add(
             new Helldivers.API.OpenApi.TypeMappers.LocalizedMessageTypeMapper(languages)
         );
+
+        document.OperationProcessors.Add(new SuperHeadersProcessor());
 
         document.DocumentProcessors.Add(new Helldivers.API.OpenApi.DocumentProcessors.HelldiversDocumentProcessor());
     });


### PR DESCRIPTION
Introduced the `SuperHeadersProcessor` class to manage required client and developer contact headers for API requests.

fixes #116