### PR TITLE
Update to .NET 9.0 and associated packages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: download JSON submodule
         run: git submodule update --init ./src/Helldivers-2-Models/json
       - name: Restore dependencies

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       - name: Install DocFX
         run: dotnet tool install -g docfx
       - name: Initial static JSON schema submodule

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 

--- a/src/Helldivers-2-API/Dockerfile
+++ b/src/Helldivers-2-API/Dockerfile
@@ -1,8 +1,8 @@
-﻿FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine-extra AS base
+﻿FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-alpine-extra AS base
 USER $APP_UID
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
 RUN apk add --upgrade --no-cache build-base clang zlib-dev
 ARG BUILD_CONFIGURATION=Release
 ARG BUILD_RUNTIME=linux-musl-x64

--- a/src/Helldivers-2-API/Helldivers-2-API.csproj
+++ b/src/Helldivers-2-API/Helldivers-2-API.csproj
@@ -23,8 +23,8 @@
 
     <!-- Dependencies for all build configurations -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
         <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
         <ProjectReference Include="..\Helldivers-2-Models\Helldivers-2-Models.csproj" />
         <ProjectReference Include="..\Helldivers-2-Core\Helldivers-2-Core.csproj" />
@@ -36,8 +36,8 @@
 
     <!-- Only include swagger dependencies in DEBUG builds -->
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
-        <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="8.0.10">
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Helldivers-2-Core/Helldivers-2-Core.csproj
+++ b/src/Helldivers-2-Core/Helldivers-2-Core.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
         <ProjectReference Include="..\Helldivers-2-Models\Helldivers-2-Models.csproj"/>
     </ItemGroup>
 

--- a/src/Helldivers-2-SourceGen/Helldivers-2-SourceGen.csproj
+++ b/src/Helldivers-2-SourceGen/Helldivers-2-SourceGen.csproj
@@ -22,9 +22,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="8.0.5" PrivateAssets="all" LocalSourceGenerators="true" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" PrivateAssets="all" LocalSourceGenerators="true" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PrivateAssets="all" LocalSourceGenerators="true" />
+        <PackageReference Include="System.Text.Json" Version="9.0.0" PrivateAssets="all" LocalSourceGenerators="true" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.0" PrivateAssets="all" LocalSourceGenerators="true" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" PrivateAssets="all" LocalSourceGenerators="true" />
     </ItemGroup>
 
     <!-- Include each nuget reference with property 'LocalSourceGenerators' into final-->

--- a/src/Helldivers-2-Sync/Helldivers-2-Sync.csproj
+++ b/src/Helldivers-2-Sync/Helldivers-2-Sync.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0"/>
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
         <ProjectReference Include="..\Helldivers-2-Core\Helldivers-2-Core.csproj" />
         <ProjectReference Include="..\Helldivers-2-Models\Helldivers-2-Models.csproj"/>


### PR DESCRIPTION
updates the application from .NET 8 to .NET 9

While .NET 9 provides it's own OpenAPI implementation, I didn't get around to upgrading away from NSwag, so that'll be for a future PR