### PR TITLE
add routing for space station endpoints added in #120

### DIFF
--- a/src/Helldivers-2-API/Controllers/V1/SpaceStationController.cs
+++ b/src/Helldivers-2-API/Controllers/V1/SpaceStationController.cs
@@ -16,7 +16,7 @@ public static class SpaceStationController
     public static async Task<IResult> Index(HttpContext context, IStore<SpaceStation, int> store)
     {
         var stations = await store.AllAsync(context.RequestAborted);
-        
+
         return Results.Ok(stations);
     }
 

--- a/src/Helldivers-2-API/Controllers/V1/SpaceStationController.cs
+++ b/src/Helldivers-2-API/Controllers/V1/SpaceStationController.cs
@@ -1,0 +1,35 @@
+using Helldivers.Core.Contracts.Collections;
+using Helldivers.Models.V1;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Helldivers.API.Controllers.V1;
+
+/// <summary>
+/// Contains API endpoints for <see cref="SpaceStation" />.
+/// </summary>
+public static class SpaceStationController
+{
+    /// <summary>
+    /// Fetches a list of all available <see cref="SpaceStation" /> information available.
+    /// </summary>
+    [ProducesResponseType<List<SpaceStation>>(StatusCodes.Status200OK)]
+    public static async Task<IResult> Index(HttpContext context, IStore<SpaceStation, int> store)
+    {
+        var stations = await store.AllAsync(context.RequestAborted);
+        
+        return Results.Ok(stations);
+    }
+
+    /// <summary>
+    /// Fetches a specific <see cref="SpaceStation" /> identified by <paramref name="index" />.
+    /// </summary>
+    public static async Task<IResult> Show(HttpContext context, IStore<SpaceStation, int> store, [FromRoute] int index)
+    {
+        var station = await store.GetAsync(index, context.RequestAborted);
+
+        if (station is null)
+            return Results.NotFound();
+
+        return Results.Ok(station);
+    }
+}

--- a/src/Helldivers-2-API/Program.cs
+++ b/src/Helldivers-2-API/Program.cs
@@ -275,6 +275,9 @@ v1.MapGet("/planets", PlanetController.Index);
 v1.MapGet("/planets/{index:int}", PlanetController.Show);
 v1.MapGet("/planet-events", PlanetController.WithEvents);
 
+v1.MapGet("/space-stations", SpaceStationController.Index);
+v1.MapGet("/space/stations/{index:int}", SpaceStationController.Show);
+
 v1.MapGet("/steam", SteamController.Index);
 v1.MapGet("/steam/{gid}", SteamController.Show);
 


### PR DESCRIPTION
we were a little too fast in #120, mapping support was present but no real API route for clients to fetch the data