### PR TITLE
[HOTFIX] make `Reward` optional in some cases

### DIFF
--- a/src/Helldivers-2-Core/Mapping/V1/AssignmentMapper.cs
+++ b/src/Helldivers-2-Core/Mapping/V1/AssignmentMapper.cs
@@ -54,7 +54,7 @@ public sealed class AssignmentMapper
             Description: LocalizedMessage.FromStrings(descriptions),
             Tasks: invariant.Setting.Tasks.Select(MapToV1).ToList(),
             Reward: MapToV1(invariant.Setting.Reward),
-            Rewards: invariant.Setting.Rewards.Select(MapToV1).ToList(),
+            Rewards: invariant.Setting.Rewards.Select(MapToV1).Where(reward => reward is not null).ToList()!,
             Expiration: expiration,
             Flags: invariant.Setting.Flags
         );
@@ -69,8 +69,11 @@ public sealed class AssignmentMapper
         );
     }
 
-    private Reward MapToV1(Models.ArrowHead.Assignments.Reward reward)
+    private Reward? MapToV1(Models.ArrowHead.Assignments.Reward? reward)
     {
+        if (reward is null)
+            return null;
+
         return new Reward(
             Type: reward.Type,
             Amount: reward.Amount

--- a/src/Helldivers-2-Models/ArrowHead/Assignments/Setting.cs
+++ b/src/Helldivers-2-Models/ArrowHead/Assignments/Setting.cs
@@ -17,7 +17,7 @@ public sealed record Setting(
     string OverrideBrief,
     string TaskDescription,
     List<Task> Tasks,
-    Reward Reward,
-    List<Reward> Rewards,
+    Reward? Reward,
+    List<Reward?> Rewards,
     int Flags
 );

--- a/src/Helldivers-2-Models/V1/Assignment.cs
+++ b/src/Helldivers-2-Models/V1/Assignment.cs
@@ -25,7 +25,7 @@ public sealed record Assignment(
     LocalizedMessage Briefing,
     LocalizedMessage Description,
     List<Task> Tasks,
-    Reward Reward,
+    Reward? Reward,
     List<Reward> Rewards,
     DateTime Expiration,
     int Flags


### PR DESCRIPTION
ArrowHead pushed an MO where the `Reward` fields are `null` which causes the current serialization process to break; effectively forcing the API offline.

This PR addresses the issue by updating the typing to account for this and will return an empty `Rewards` list (and `null` for `Reward`) if there's no rewards.

While this is a breaking change, we don't have much choice between making up data or breaking the interface.