### PR TITLE
Change space station's `deltaPerSecond` to double

### DIFF
--- a/src/Helldivers-2-Models/ArrowHead/SpaceStations/Cost.cs
+++ b/src/Helldivers-2-Models/ArrowHead/SpaceStations/Cost.cs
@@ -15,7 +15,7 @@ public sealed record Cost(
     long ItemMixId,
     long TargetValue,
     double CurrentValue,
-    long DeltaPerSecond,
+    double DeltaPerSecond,
     long MaxDonationAmmount,
     long MaxDonationPeriodSeconds
 );

--- a/src/Helldivers-2-Models/V2/SpaceStations/Cost.cs
+++ b/src/Helldivers-2-Models/V2/SpaceStations/Cost.cs
@@ -15,7 +15,7 @@ public sealed record Cost(
     long ItemMixId,
     long TargetValue,
     double CurrentValue,
-    long DeltaPerSecond,
+    double DeltaPerSecond,
     long MaxDonationAmmount,
     long MaxDonationPeriodSeconds
 );


### PR DESCRIPTION
ArrowHead's space station endpoint returns doubles, not whole numbers and that's causing parsing errors, again.