### PR TITLE
CI sync

### DIFF
--- a/Helldivers-2.sln
+++ b/Helldivers-2.sln
@@ -56,6 +56,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "OpenApi", "OpenApi", "{1A2C
 		docs\openapi\Helldivers-2-API_arrowhead.json = docs\openapi\Helldivers-2-API_arrowhead.json
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Helldivers-2-CI", "src\Helldivers-2-CI\Helldivers-2-CI.csproj", "{DD942DB1-162A-4915-B10E-C049ED478297}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +84,10 @@ Global
 		{32AE19FB-7D9E-4AC7-A0A5-80DED3680369}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{32AE19FB-7D9E-4AC7-A0A5-80DED3680369}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{32AE19FB-7D9E-4AC7-A0A5-80DED3680369}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD942DB1-162A-4915-B10E-C049ED478297}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD942DB1-162A-4915-B10E-C049ED478297}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD942DB1-162A-4915-B10E-C049ED478297}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD942DB1-162A-4915-B10E-C049ED478297}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Helldivers-2-CI/Helldivers-2-CI.csproj
+++ b/src/Helldivers-2-CI/Helldivers-2-CI.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net9.0</TargetFramework>
+        <RootNamespace>Helldivers_2_CI</RootNamespace>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
+      <ProjectReference Include="..\Helldivers-2-Sync\Helldivers-2-Sync.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Helldivers-2-CI/Program.cs
+++ b/src/Helldivers-2-CI/Program.cs
@@ -1,0 +1,52 @@
+﻿using Helldivers.Core.Extensions;
+using Helldivers.Sync.Configuration;
+using Helldivers.Sync.Extensions;
+using Helldivers.Sync.Hosted;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+
+var maxRuntime = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+var builder = new HostApplicationBuilder(args);
+
+builder.Services.AddHelldivers();
+builder.Services.AddHelldiversSync();
+builder.Services.Configure<HelldiversSyncConfiguration>(configuration =>
+{
+    configuration.RunOnce = true;
+    // Add all languages we want to CI test here.
+    configuration.Languages =
+    [
+        "en-US",
+        "de-DE",
+        "es-ES",
+        "ru-RU",
+        "fr-FR",
+        "it-IT",
+        "pl-PL",
+        "zh-Hans",
+        "zh-Hant"
+    ];
+});
+
+var stopwatch = new Stopwatch();
+var app = builder.Build();
+
+// Run our host, but make it shutdown after *max* 30 seconds.
+stopwatch.Start();
+var arrowhead = app.Services.GetRequiredService<ArrowHeadSyncService>();
+var steam =  app.Services.GetRequiredService<SteamSyncService>();
+await arrowhead.StartAsync(maxRuntime.Token);
+await steam.StartAsync(maxRuntime.Token);
+
+// now we await completion of both.
+await Task.WhenAll([
+    arrowhead.ExecuteTask!,
+    steam.ExecuteTask!,
+]).WaitAsync(maxRuntime.Token);
+stopwatch.Stop();
+
+app.Services.GetRequiredService<ILogger<Program>>().LogInformation("Sync succeeded in {}", stopwatch.Elapsed);
+
+return 0;

--- a/src/Helldivers-2-Sync/Configuration/HelldiversSyncConfiguration.cs
+++ b/src/Helldivers-2-Sync/Configuration/HelldiversSyncConfiguration.cs
@@ -24,4 +24,10 @@ public sealed class HelldiversSyncConfiguration
     /// A list of language codes for which translations will be provided.
     /// </summary>
     public List<string> Languages { get; set; } = new(0);
+
+    /// <summary>
+    /// Flag to indicate if the application should only run the sync once.
+    /// This is used in CI testing to validate sync works.
+    /// </summary>
+    public bool RunOnce { get; set; } = false;
 }


### PR DESCRIPTION
The goal of this PR is to have a periodically running CI system that performs the full sync daily/weekly/hourly

A separate CLI binary pulls in the API's sync services and runs them (once) and validates they ran to completion without any errors.
We can also have this run  on any PR, allowing us to catch this category of errors much earlier than "an end user reported errors"

This was originally discussed in the [Helldivers Discord](https://discord.com/channels/1214610835524296704/1214610836396707863/1380114342602739752)

Roadmap:
- [ ] Create CLI binary that pulls in the sync and runs it
- [ ] Have it generate error reports
- [ ] run CLI hourly/daily/weekly (to be discussed)
- [ ] run CLI for every PR to validate sync