### PR TITLE
Super headers as query

### DIFF
--- a/src/Helldivers-2-API/Metrics/ClientMetric.cs
+++ b/src/Helldivers-2-API/Metrics/ClientMetric.cs
@@ -71,4 +71,13 @@ public static partial class ClientMetric
 
         return result;
     }
+
+    private static string? GetSuperClient(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(Constants.CLIENT_HEADER_NAME, out var superClient))
+            if (string.IsNullOrWhiteSpace(superClient) is false)
+                return superClient;
+
+        return context.Request.Query[Constants.CLIENT_HEADER_NAME.ToLowerInvariant()];
+    }
 }

--- a/src/Helldivers-2-API/Middlewares/RateLimitMiddleware.cs
+++ b/src/Helldivers-2-API/Middlewares/RateLimitMiddleware.cs
@@ -62,8 +62,8 @@ public sealed partial class RateLimitMiddleware(
         if (options.Value.ValidateClients is false || context.Request.Path.StartsWithSegments("/metrics"))
             return true;
 
-        return context.Request.Headers.ContainsKey(Constants.CLIENT_HEADER_NAME)
-            && context.Request.Headers.ContainsKey(Constants.CONTACT_HEADER_NAME);
+        return HasSuperHeaderOrQuery(context, Constants.CLIENT_HEADER_NAME)
+            && HasSuperHeaderOrQuery(context, Constants.CONTACT_HEADER_NAME);
     }
 
     private RateLimiter GetRateLimiter(HttpContext http)
@@ -121,5 +121,13 @@ public sealed partial class RateLimitMiddleware(
         writer.WriteEndObject();
 
         await writer.FlushAsync(context.RequestAborted);
+    }
+
+    private bool HasSuperHeaderOrQuery(HttpContext context, string name)
+    {
+        if (context.Request.Headers.ContainsKey(name))
+            return true;
+
+        return context.Request.Query.ContainsKey(name.ToLowerInvariant());
     }
 }


### PR DESCRIPTION
Someone in the Discord mentioned some clients don't allow passing in headers (such as VR Chat), this PR adds support for passing them in as query parameters as well.