### PR TITLE
Add security schemes for SwaggerUI authentication in OpenAPI

### DIFF
--- a/src/Helldivers-2-API/OpenApi/DocumentProcessors/HelldiversDocumentProcessor.cs
+++ b/src/Helldivers-2-API/OpenApi/DocumentProcessors/HelldiversDocumentProcessor.cs
@@ -41,6 +41,30 @@ public class HelldiversDocumentProcessor : IDocumentProcessor
                 property.OneOf.Clear();
             }
         }
+
+        context.Document.SecurityDefinitions.Add(Constants.CLIENT_HEADER_NAME, new OpenApiSecurityScheme
+        {
+            Type = OpenApiSecuritySchemeType.ApiKey,
+            In = OpenApiSecurityApiKeyLocation.Header,
+            Name = Constants.CLIENT_HEADER_NAME,
+            Description = "A unique name that identifies your client to the API."
+        });
+
+        context.Document.SecurityDefinitions.Add(Constants.CONTACT_HEADER_NAME, new OpenApiSecurityScheme
+        {
+            Type = OpenApiSecuritySchemeType.ApiKey,
+            In = OpenApiSecurityApiKeyLocation.Header,
+            Name = Constants.CONTACT_HEADER_NAME,
+            Description = "Contact information for the developer (e.g. an email address or URL)."
+        });
+
+        context.Document.SecurityDefinitions.Add("Bearer", new OpenApiSecurityScheme
+        {
+            Type = OpenApiSecuritySchemeType.Http,
+            Scheme = "bearer",
+            BearerFormat = "JWT",
+            Description = "A JWT bearer token for authenticated access."
+        });
     }
 }
 #endif

--- a/src/Helldivers-2-API/OpenApi/OperationProcessors/SuperHeadersProcessor.cs
+++ b/src/Helldivers-2-API/OpenApi/OperationProcessors/SuperHeadersProcessor.cs
@@ -14,27 +14,12 @@ public class SuperHeadersProcessor : IOperationProcessor
     /// <inheritdoc />
     public bool Process(OperationProcessorContext context)
     {
-        context.OperationDescription.Operation.Parameters.Add(
-            new OpenApiParameter
+        context.OperationDescription.Operation.Security ??= [];
+        context.OperationDescription.Operation.Security.Add(
+            new OpenApiSecurityRequirement
             {
-                Name = Constants.CLIENT_HEADER_NAME,
-                Kind = OpenApiParameterKind.Header,
-                Type = NJsonSchema.JsonObjectType.String,
-                IsRequired = true,
-                Description = "The name of the header that identifies the client to the API.",
-                Default = string.Empty
-            }
-        );
-
-        context.OperationDescription.Operation.Parameters.Add(
-            new OpenApiParameter
-            {
-                Name = Constants.CONTACT_HEADER_NAME,
-                Kind = OpenApiParameterKind.Header,
-                Type = NJsonSchema.JsonObjectType.String,
-                IsRequired = true,
-                Description = "The name of the header with developer contact information.",
-                Default = string.Empty
+                { Constants.CLIENT_HEADER_NAME, [] },
+                { Constants.CONTACT_HEADER_NAME, [] }
             }
         );
 


### PR DESCRIPTION
## Summary
Adds security scheme definitions to the OpenAPI document so that SwaggerUI displays an "Authorize" button, allowing users to set _X-Super-Client_ and _X-Super-Contact_ once rather than per-endpoint.

## Changes
- `HelldiversDocumentProcessor.cs` - registers security schemes on the OpenAPI document
- `SuperHeadersProcessor.cs` - applies security requirements to operations that require auth headers

## Notes
Closes #159 
No breaking changes. Purely additive to the OpenAPI spec generation.