### PR TITLE
docs: add Related Resources section (Helldivers 2 Guides companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ Check out some awesome projects made by our community!
   The Galactic Wide Web - a discord bot
 - [helldivers-2/api-wrapper](https://github.com/helldivers-2/api-wrapper)
   Typescript client code generated from OpenAPI
+- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.


### PR DESCRIPTION
Thanks for maintaining the Helldivers 2 community API — players often need guide hubs alongside the data.

This PR adds a single link to the existing Related/Resources section pointing to a companion player-facing guide site:

- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `append_to:## Community`.)_